### PR TITLE
Special case Lock service method paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Build
 -----
 
 ```
-$ rebar3 compile
+rebar3 compile
 ```
 
 Use
@@ -15,9 +15,14 @@ Use
 
 Add the plugin to your rebar config:
 
-```
+``` erlang
 {deps, [eetcd]}.
 
 {plugins, [rebar3_gbp_plugin, rebar3_eetcd_plugin]}.
 ```
 
+and then run generation:
+
+```shell
+rebar3 etcd gen
+```

--- a/priv/eetcd_client.template
+++ b/priv/eetcd_client.template
@@ -1,7 +1,8 @@
 {description, "ETCD v3 client template"}.
 {variables,
- [{unmodified_service_name, [], "Original name of the service, as it'll appear in a request"},
+ [{unmodified_service_name, "", "Original name of the service, as it'll appear in a request"},
+  {full_service_path, "", "gRPC service path"},
   {pb_module, "", "Name of protobuf module to get type specs from"},
-  {service_name, [], "Name of service"},
+  {service_name, [], "Name of the service"},
   {methods, [], "List of methods for service"}]}.
 {template, "eetcd_sample_client.erl", "{{out_dir}}/clients/eetcd_{{module_name}}_gen.erl"}.

--- a/priv/eetcd_client.template
+++ b/priv/eetcd_client.template
@@ -1,7 +1,6 @@
 {description, "ETCD v3 client template"}.
 {variables,
  [{unmodified_service_name, "", "Original name of the service, as it'll appear in a request"},
-  {full_service_path, "", "gRPC service path"},
   {pb_module, "", "Name of protobuf module to get type specs from"},
   {service_name, [], "Name of the service"},
   {methods, [], "List of methods for service"}]}.

--- a/priv/eetcd_sample_client.erl
+++ b/priv/eetcd_sample_client.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%% @doc Behaviour to implement for eectd {{unmodified_service_name}} (path: "{{full_service_path}}").
+%% @doc Behaviour to implement for eectd {{unmodified_service_name}}
 %% @private
 %%  All detail documents please visit https://github.com/etcd-io/etcd/blob/master/Documentation/dev-guide/api_reference_v3.md
 %% @end

--- a/priv/eetcd_sample_client.erl
+++ b/priv/eetcd_sample_client.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%% @doc Behaviour to implement for eectd {{unmodified_service_name}}.
+%% @doc Behaviour to implement for eectd {{unmodified_service_name}} (path: "{{full_service_path}}").
 %% @private
 %%  All detail documents please visit https://github.com/etcd-io/etcd/blob/master/Documentation/dev-guide/api_reference_v3.md
 %% @end
@@ -14,10 +14,10 @@
 {{/methods}}
 
 {{#methods}}
-%% @doc {{^output_stream}}{{^input_stream}}Unary RPC {{/input_stream}}{{#input_stream}}Stream RPC {{/input_stream}}{{/output_stream}}
+%% @doc {{^output_stream}}{{^input_stream}}Unary RPC for service at path "{{full_service_path}}" {{/input_stream}}{{#input_stream}}Stream RPC {{/input_stream}}{{/output_stream}}
 -spec {{method}}(router_pb:'{{input}}'()) ->
     {{^output_stream}}{{^input_stream}}{ok, router_pb:'{{output}}'()}{{/input_stream}}{{#input_stream}}reference(){{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}reference(){{/input_stream}}{{#input_stream}}reference(){{/input_stream}}{{/output_stream}}|{error,eetcd:eetcd_error()}.
 {{method}}(Request) ->
-    {{^output_stream}}{{^input_stream}}eetcd_stream:unary(Request, '{{input}}', <<"/etcdserverpb.{{unmodified_service_name}}/{{unmodified_method}}">>, '{{output}}'){{/input_stream}}{{#input_stream}}eetcd_stream:new(Request, <<"/etcdserverpb.{{unmodified_service_name}}/{{unmodified_method}}">>){{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}eetcd_stream:new(Request, <<"/etcdserverpb.{{unmodified_service_name}}/{{unmodified_method}}">>){{/input_stream}}{{/output_stream}}.
+    {{^output_stream}}{{^input_stream}}eetcd_stream:unary(Request, '{{input}}', <<"{{full_service_path}}">>, '{{output}}'){{/input_stream}}{{#input_stream}}eetcd_stream:new(Request, <<"{{full_service_path}}">>){{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}eetcd_stream:new(Request, <<"{{full_service_path}}">>){{/input_stream}}{{/output_stream}}.
 
 {{/methods}}

--- a/src/rebar3_eetcd_plugin.app.src
+++ b/src/rebar3_eetcd_plugin.app.src
@@ -1,6 +1,6 @@
 {application,rebar3_eetcd_plugin,
              [{description,"Rebar3 plugin to generate client for eetcd"},
-              {vsn,"0.2.0"},
+              {vsn,"0.3.0"},
               {registered,[]},
               {applications,[kernel,stdlib,gpb,providers]},
               {env,[]},

--- a/src/rebar3_eetcd_prv_compile.erl
+++ b/src/rebar3_eetcd_prv_compile.erl
@@ -19,7 +19,7 @@ init(State) ->
         {module, ?MODULE},            % The module implementation of the task
         {bare, true},                 % The task can be run by the user, always true
         {deps, ?DEPS},                % The list of dependencies
-        {example, "rebar3 eetcd gen"}, % How to use the plugin
+        {example, "rebar3 etcd gen"}, % How to use the plugin
         {opts, []},                   % list of options understood by the plugin
         {short_desc, "Generates ETCD client protos"},
         {desc, "Generates ETCD V3 client protos"}
@@ -34,10 +34,12 @@ do(State) ->
     {Options, _} = rebar_state:command_parsed_args(State),
     ProtoDir = proplists:get_value(protos, Options, proplists:get_value(protos, EtcdConfig, "priv/protos")),
     GpbOpts = proplists:get_value(gpb_opts, EtcdConfig, []),
-    
+
     [begin
          GpbModule = compile_pb(Filename, GpbOpts),
-         gen_client_module(GpbModule, Options, EtcdConfig, State)
+         rebar_api:info("Compiled PB file ~s~n", [Filename]),
+         gen_client_module(GpbModule, Options, EtcdConfig, State),
+         rebar_api:info("Generated a client module for PB module ~s~n", [GpbModule])
      end || Filename <- filelib:wildcard(filename:join(ProtoDir, "*.proto"))],
     {ok, State}.
 
@@ -50,12 +52,7 @@ compile_pb(Filename, Options) ->
     ModuleNameSuffix = proplists:get_value(module_name_suffix, Options, "_pb"),
     ModuleNamePrefix = proplists:get_value(module_name_prefix, Options, ""),
     CompiledPB = filename:join(OutDir, ModuleNamePrefix ++ filename:basename(Filename, ".proto") ++ ModuleNameSuffix ++ ".erl"),
-    rebar_log:log(info, "Writing ~s", [CompiledPB]),
-    %ok = gpb_compile:file(Filename, [
-    %    {rename, {msg_name, snake_case}},
-    %    {rename, {msg_fqname, base_name}},
-    %    use_packages, maps,
-    %    strings_as_binaries, {i, "."}, {o, OutDir} | Options]),
+    rebar_api:info("Writing ~s", [CompiledPB]),
     GpbIncludeDir = filename:join(code:lib_dir(gpb), "include"),
     case compile:file(CompiledPB,
         [binary, {i, GpbIncludeDir}, {i, "./include/"}, return_errors]) of
@@ -76,11 +73,12 @@ compile_pb(Filename, Options) ->
 gen_client_module(GpbModule, Options, EtcdConfig, State) ->
     OutDir = proplists:get_value(out_dir, EtcdConfig, "src"),
     Force = proplists:get_value(force, Options, true),
+    rebar_api:debug("GPB module service names: ~p", [GpbModule:get_service_names()]),
     Services = [begin
                     {{_, NameAtom}, Methods} = GpbModule:get_service_def(S),
                     Name = atom_to_list(NameAtom),
                     [_, Module] = string:tokens(Name, "."),
-                    rebar_log:log(debug, "GpbModule: ~p~n", [{GpbModule, Name, Methods}]),
+                    rebar_api:debug("GPB module: ~p~n", [{GpbModule, Name, Methods}]),
                     [
                         {out_dir, OutDir},
                         {pb_module, atom_to_list(GpbModule)},
@@ -90,16 +88,17 @@ gen_client_module(GpbModule, Options, EtcdConfig, State) ->
                             [begin
                                  %% {rpc, MethodName, Input,  Output, InputStream, OutputStream, _Opts} = Method,
                                  #{input := Input,
-                                     input_stream := InputStream,
-                                     name := MethodName,
-                                     opts := _Opts,
-                                     output := Output,
-                                     output_stream := OutputStream} = Method,
+                                   input_stream := InputStream,
+                                   name := MethodName,
+                                   opts := _Opts,
+                                   output := Output,
+                                   output_stream := OutputStream} = Method,
                                  MethodNameStr = atom_to_list(MethodName),
                                  [
                                      {method, list_snake_case(MethodNameStr)},
                                      {unmodified_service_name, Module},
                                      {unmodified_method, MethodNameStr},
+                                     {full_service_path, full_service_path(Name, MethodNameStr)},
                                      {pb_module, atom_to_list(GpbModule)},
                                      {input, Input},
                                      {output, Output},
@@ -108,7 +107,7 @@ gen_client_module(GpbModule, Options, EtcdConfig, State) ->
                                  ]
                              end|| Method <- Methods]}]
                 end || S <- GpbModule:get_service_names()],
-    rebar_log:log(debug, "services: ~p", [Services]),
+    rebar_api:debug("Services to run module generation for: ~p", [Services]),
     [rebar_templater:new("eetcd_client", Service, Force, State) || Service <- Services].
 
 list_snake_case(NameString) ->
@@ -124,3 +123,9 @@ list_snake_case(NameString) ->
     Snaked1 = string:replace(Snaked, ".", "_", all),
     Snaked2 = string:replace(Snaked1, "__", "_", all),
     string:to_lower(unicode:characters_to_list(Snaked2)).
+
+%% Calculates correct gRPC service path
+full_service_path(Service, Method) when Service =:= "Etcd.Lock"; Service =:= "Lock" ->
+    io_lib:format("/v3lockpb.Lock/~p", [Method]);
+full_service_path(Service, Method) ->
+    io_lib:format("/etcdserverpb.~s/~s", [Service, Method]).

--- a/src/rebar3_eetcd_prv_compile.erl
+++ b/src/rebar3_eetcd_prv_compile.erl
@@ -105,7 +105,7 @@ format_methods(Module, Name, GpbModule, Methods) ->
              {method,                  list_snake_case(MethodNameStr)},
              {unmodified_service_name, Module},
              {unmodified_method,       MethodNameStr},
-             {full_service_path,       full_service_path(Name, MethodNameStr)},
+             {full_service_path,       full_service_path(Module, MethodNameStr)},
              {pb_module,               atom_to_list(GpbModule)},
              {input,                   Input},
              {output,                  Output},
@@ -129,7 +129,7 @@ list_snake_case(NameString) ->
     string:to_lower(unicode:characters_to_list(Snaked2)).
 
 %% Calculates correct gRPC service path
-full_service_path(Service, Method) when Service =:= "Etcd.Lock"; Service =:= "Lock" ->
+full_service_path(Service, Method) when Service =:= "Lock" ->
     io_lib:format("/v3lockpb.Lock/~s", [Method]);
 full_service_path(Service, Method) ->
     io_lib:format("/etcdserverpb.~s/~s", [Service, Method]).


### PR DESCRIPTION
Since they don't match the typical `/etcdserverpb.{service_name}/{method}`
pattern and instead it is `/v3lockpb.Lock/{method}`.

Part of zhongwencool/eetcd#16.