### PR TITLE
correct function spec in sample client template

### DIFF
--- a/priv/eetcd_sample_client.erl
+++ b/priv/eetcd_sample_client.erl
@@ -15,7 +15,7 @@
 
 {{#methods}}
 %% @doc {{^output_stream}}{{^input_stream}}Unary RPC for service at path "{{full_service_path}}" {{/input_stream}}{{#input_stream}}Stream RPC {{/input_stream}}{{/output_stream}}
--spec {{method}}(router_pb:'{{input}}'()) ->
+-spec {{method}}({{#input_stream}}atom()|reference(){{/input_stream}}{{^input_stream}}router_pb:'{{input}}'(){{/input_stream}}) ->
     {{^output_stream}}{{^input_stream}}{ok, router_pb:'{{output}}'()}{{/input_stream}}{{#input_stream}}{ok, GunPid :: pid(), Http2Ref:: reference()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, GunPid :: pid(), Http2Ref:: reference()}{{/input_stream}}{{#input_stream}}{ok, GunPid :: pid(), Http2Ref:: reference()}{{/input_stream}}{{/output_stream}}|{error,eetcd:eetcd_error()}.
 {{method}}(Request) ->
     {{^output_stream}}{{^input_stream}}eetcd_stream:unary(Request, '{{input}}', <<"{{full_service_path}}">>, '{{output}}'){{/input_stream}}{{#input_stream}}eetcd_stream:new(Request, <<"{{full_service_path}}">>){{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}eetcd_stream:new(Request, <<"{{full_service_path}}">>){{/input_stream}}{{/output_stream}}.


### PR DESCRIPTION
When `input_stream` is `true`, the `input` type should be `atom() | reference()`.